### PR TITLE
Allow .json files to have query parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotlottie/player-component",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "dotlottie animation player web component.",
   "main": "dist/dotlottie-player.js",
   "module": "dist/dotlottie-player.esm.js",

--- a/src/dotlottie-player.ts
+++ b/src/dotlottie-player.ts
@@ -45,7 +45,7 @@ export type Versions = {
  * Load a resource from a path URL.
  */
 export function fetchPath(path: string): Record<string, any> {
-  const fileFormat = path.split('.').pop()?.toLowerCase();
+  const fileFormat = path.split(/[#?]/)[0].split('.').pop()?.toLowerCase();
   let jsonFlag = false;
 
   if (fileFormat === 'json') jsonFlag = true;


### PR DESCRIPTION
Currently, when the src contains query parameters such as `uplaods/animation.json?version=123` the fileFormat returns `json?version=123` and it isn't flagged as a json file.