### PR TITLE
feat: add support to change the player mode

### DIFF
--- a/.changeset/five-terms-occur.md
+++ b/.changeset/five-terms-occur.md
@@ -1,0 +1,5 @@
+---
+'@dotlottie/player-component': minor
+---
+
+Add support to change the player mode using `setPlayMode` that accepts `normal` or `bounce`

--- a/packages/player-component/src/dotlottie-player.ts
+++ b/packages/player-component/src/dotlottie-player.ts
@@ -555,6 +555,16 @@ export class DotLottiePlayer extends LitElement {
   }
 
   /**
+   * Sets the player mode
+   * @param mode - The mode to set ('normal', 'bounce')
+   */
+  public setPlayMode(mode: PlayMode): void {
+    if (!this._dotLottieCommonPlayer) return;
+
+    this._dotLottieCommonPlayer.setMode(mode);
+  }
+
+  /**
    * Reverts PlaybackOptions to manifest values instead of player props.
    */
   public revertToManifestValues(playbackKeys?: Array<keyof PlaybackOptions | 'activeAnimationId'>): void {


### PR DESCRIPTION
## Description

This exposes a method `setPlayMode` to change the `mode` of the player to `normal` | `bounce`.

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Docs: Documentation updates (if none of the other choices apply)

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested my changes on the player-component and React player.