### PR TITLE
fix: 🐛 double render when selecting animations

### DIFF
--- a/.changeset/mean-feet-remember.md
+++ b/.changeset/mean-feet-remember.md
@@ -1,0 +1,5 @@
+---
+'@dotlottie/player-component': patch
+---
+
+fix: 🐛 double render when selective animations.

--- a/packages/player-component/src/dotlottie-player.ts
+++ b/packages/player-component/src/dotlottie-player.ts
@@ -989,16 +989,14 @@ export class DotLottiePlayer extends LitElement {
                                 @click=${(): void => {
                                   this._animationsTabIsOpen = !this._animationsTabIsOpen;
                                   this._popoverIsOpen = !this._popoverIsOpen;
-                                  this.setTheme('');
-                                  this.play(animationName);
+                                  this.play(animationName, (prev) => ({ ...prev, defaultTheme: '' }));
                                   this.requestUpdate();
                                 }}
                                 @keydown=${(key: KeyboardEvent): void => {
                                   if (key.code === 'Space' || key.code === 'Enter') {
                                     this._animationsTabIsOpen = !this._animationsTabIsOpen;
                                     this._popoverIsOpen = !this._popoverIsOpen;
-                                    this.setTheme('');
-                                    this.play(animationName);
+                                    this.play(animationName, (prev) => ({ ...prev, defaultTheme: '' }));
                                     this.requestUpdate();
                                   }
                                 }}


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request.

If this addresses an existing issue, please include the issue number in the #1234 form.
-->

## Type of change

<!--
Remember to indicate the affected component/package(s), as well as the type of change for each component/package.

Adding an x between the [ ] will render it as a checked box (i.e. [x]).
-->

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Docs: Documentation updates (if none of the other choices apply)

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested my changes on the player-component and React player.