### PR TITLE
feat: complete fires when direction -1

### DIFF
--- a/.changeset/lazy-icons-clap.md
+++ b/.changeset/lazy-icons-clap.md
@@ -1,0 +1,5 @@
+---
+'@dotlottie/common': minor
+---
+
+fires the complete event if direction is -1 and frame 0 is hit

--- a/packages/common/src/dotlottie-player.ts
+++ b/packages/common/src/dotlottie-player.ts
@@ -1517,7 +1517,7 @@ export class DotLottiePlayer {
 
     this._lottie.addEventListener('enterFrame', () => {
       if (Math.floor(this._frame) >= 0 && Math.floor(this._frame) < 1 && this.direction === -1) {
-        this._handleAnimationComplete();
+        this._container?.dispatchEvent(new Event(PlayerEvents.Complete));
       }
       // Update seeker and frame value based on the current animation frame
       if (!this._lottie) {

--- a/packages/common/src/dotlottie-player.ts
+++ b/packages/common/src/dotlottie-player.ts
@@ -1516,6 +1516,9 @@ export class DotLottiePlayer {
     }
 
     this._lottie.addEventListener('enterFrame', () => {
+      if (Math.round(this._frame) >= 0 && Math.round(this._frame) < 1 && this.direction === -1) {
+        this._handleAnimationComplete();
+      }
       // Update seeker and frame value based on the current animation frame
       if (!this._lottie) {
         logWarning('enterFrame event : Lottie is undefined.');

--- a/packages/common/src/dotlottie-player.ts
+++ b/packages/common/src/dotlottie-player.ts
@@ -1516,7 +1516,7 @@ export class DotLottiePlayer {
     }
 
     this._lottie.addEventListener('enterFrame', () => {
-      if (Math.round(this._frame) >= 0 && Math.round(this._frame) < 1 && this.direction === -1) {
+      if (Math.floor(this._frame) >= 0 && Math.floor(this._frame) < 1 && this.direction === -1) {
         this._handleAnimationComplete();
       }
       // Update seeker and frame value based on the current animation frame

--- a/packages/common/src/dotlottie-player.ts
+++ b/packages/common/src/dotlottie-player.ts
@@ -1516,17 +1516,27 @@ export class DotLottiePlayer {
     }
 
     this._lottie.addEventListener('enterFrame', () => {
-      if (Math.floor(this._frame) >= 0 && Math.floor(this._frame) < 1 && this.direction === -1) {
-        this._container?.dispatchEvent(new Event(PlayerEvents.Complete));
-      }
       // Update seeker and frame value based on the current animation frame
       if (!this._lottie) {
         logWarning('enterFrame event : Lottie is undefined.');
 
         return;
       }
+      const flooredFrame = Math.floor(this._lottie.currentFrame);
+
       this._frame = this._lottie.currentFrame;
       this._seeker = (this._lottie.currentFrame / this._lottie.totalFrames) * 100;
+
+      if (flooredFrame === 0) {
+        this._frame = flooredFrame;
+        this._seeker = flooredFrame;
+
+        if (this.direction === -1) {
+          this._container?.dispatchEvent(new Event(PlayerEvents.Complete));
+          if (!this.loop) this.setCurrentState(PlayerState.Completed);
+        }
+      }
+
       // Notify state subscriptions about the frame and seeker update.
       this._notify();
     });

--- a/packages/player-component/cypress/component/direction.cy.ts
+++ b/packages/player-component/cypress/component/direction.cy.ts
@@ -2,6 +2,7 @@
  * Copyright 2023 Design Barn Inc.
  */
 
+import { PlayerState } from '@dotlottie/common';
 import { html } from 'lit';
 
 describe('Direction', () => {
@@ -53,4 +54,26 @@ describe('Direction', () => {
 
     cy.get('[name="direction"]').should('have.value', -1);
   });
+
+  it('should be able to change direction to -1 and be in completed state', () => {
+    cy.mount(
+      html`
+        <dotlottie-player
+          data-testid="testPlayer"
+          direction=${-1}
+          autoplay
+          speed=${5}
+          controls
+          style="height: 200px;"
+          src="/cool-dog.lottie"
+        >
+        </dotlottie-player>
+      `,
+    );
+
+    cy.get('[name="direction"]').should('have.value', -1);
+    cy.get('[name="frame"]').should('have.value', 0);
+    cy.get('[name="currentState"]').should('have.value', PlayerState.Completed);
+  });
+
 });

--- a/packages/react-player/cypress/component/direction.cy.tsx
+++ b/packages/react-player/cypress/component/direction.cy.tsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react';
 import { Controls } from '../../src/controls';
 import { DotLottiePlayer } from '../../src/react-player';
 import { PlayerStateWrapper } from '../support/player-state-wrapper';
+import { PlayerState } from '@dotlottie/common';
 
 describe('Direction', () => {
   it('direction should default to 1', () => {
@@ -56,6 +57,28 @@ describe('Direction', () => {
     );
 
     cy.get('[name="direction"]').should('have.value', -1);
+  });
+
+  it('should be able to change direction to -1 and be in completed state', () => {
+    cy.mount(
+      <PlayerStateWrapper>
+        <DotLottiePlayer
+          src={`/cool-dog.lottie`}
+          style={{ height: '400px', display: 'inline-block' }}
+          autoplay
+          loop={false}
+          speed={5}
+          direction={-1}
+        >
+          <Controls />
+        </DotLottiePlayer>
+        ,
+      </PlayerStateWrapper>,
+    );
+
+    cy.get('[name="direction"]').should('have.value', -1);
+    cy.get('[name="frame"]').should('have.value', 0);
+    cy.get('[name="currentState"]').should('have.value', PlayerState.Completed);
   });
 
   it('direction should be reactive.', () => {


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request.

If this addresses an existing issue, please include the issue number in the #1234 form.
-->

When direction is -1 and the current frame hits 0, it fires the complete event.

## Type of change

<!--
Remember to indicate the affected component/package(s), as well as the type of change for each component/package.

Adding an x between the [ ] will render it as a checked box (i.e. [x]).
-->

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Docs: Documentation updates (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested my changes on the player-component and React player.