### PR TITLE
fix: replace structuredClone with Object.assign

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,7 @@ module.exports = {
     '@typescript-eslint/prefer-for-of': 'off',
     '@typescript-eslint/dot-notation': 'off',
     '@typescript-eslint/member-ordering': 'off',
-    'prefer-object-spread': 'off',
+    'prefer-object-spread': 'warn',
 
     // Disable the async generator warning
     'no-restricted-syntax': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,7 @@ module.exports = {
     '@typescript-eslint/prefer-for-of': 'off',
     '@typescript-eslint/dot-notation': 'off',
     '@typescript-eslint/member-ordering': 'off',
+    'prefer-object-spread': 'off',
 
     // Disable the async generator warning
     'no-restricted-syntax': 'off',

--- a/packages/common/src/dotlottie-player.ts
+++ b/packages/common/src/dotlottie-player.ts
@@ -214,7 +214,8 @@ export class DotLottieCommonPlayer {
     container?: DotLottieElement | null,
     options?: DotLottieConfig<RendererType>,
   ) {
-    this._src = structuredClone(src);
+    if (typeof src === 'string') this._src = src;
+    else this._src = Object.assign({}, src);
 
     if (options?.testId) {
       this._testId = options.testId;
@@ -482,7 +483,8 @@ export class DotLottieCommonPlayer {
 
   public updateSrc(src: Record<string, unknown> | string): void {
     if (this._src === src) return;
-    this._src = structuredClone(src);
+    if (typeof src === 'string') this._src = src;
+    else this._src = Object.assign({}, src);
     this._activeAnimationId = undefined;
     this._currentAnimationId = undefined;
     this.load();


### PR DESCRIPTION
## Description

Replaces structuredClone with Object.assign in dotlottie-player.ts
Fixes - #256 

## Type of change

Affects `common/src/dotlottie-player.ts`

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Docs: Documentation updates (if none of the other choices apply)

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested my changes on the player-component and React player.