### PR TITLE
fix: 🐛 useLayoutEffect does nothing on the server warning

### DIFF
--- a/.changeset/tidy-panthers-itch.md
+++ b/.changeset/tidy-panthers-itch.md
@@ -1,0 +1,5 @@
+---
+'@dotlottie/react-player': patch
+---
+
+fix: 🐛 useLayoutEffect does nothing on the server warning

--- a/packages/react-player/src/hooks/use-dotlottie-player.ts
+++ b/packages/react-player/src/hooks/use-dotlottie-player.ts
@@ -5,7 +5,9 @@
 import type { DotLottieConfig, DotLottieElement, RendererType } from '@dotlottie/common';
 import { DotLottieCommonPlayer } from '@dotlottie/common';
 import type { MutableRefObject } from 'react';
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useLayoutEffect, useRef, useState, useEffect } from 'react';
+
+export const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
 export const useDotLottiePlayer = (
   src: Record<string, unknown> | string,
@@ -16,7 +18,7 @@ export const useDotLottiePlayer = (
 
   const loadedRef = useRef(false);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     async function load(): Promise<void> {
       if (!loadedRef.current && containerRef.current) {
         loadedRef.current = true;


### PR DESCRIPTION
## Description

fix #273 

<!--
Please include a summary of what you want to achieve in this pull request.

If this addresses an existing issue, please include the issue number in the #1234 form.
-->

## Type of change

<!--
Remember to indicate the affected component/package(s), as well as the type of change for each component/package.

Adding an x between the [ ] will render it as a checked box (i.e. [x]).
-->

`@dotlottie/react-player`

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Docs: Documentation updates (if none of the other choices apply)

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested my changes on the player-component and React player.