### PR TITLE
Fix/278 making responsive lotties

### DIFF
--- a/.changeset/green-parrots-wink.md
+++ b/.changeset/green-parrots-wink.md
@@ -1,0 +1,5 @@
+---
+'@dotlottie/react-player': patch
+---
+
+fix: 🐛 removed the use of css file when there are no controls

--- a/packages/react-player/src/react-player.tsx
+++ b/packages/react-player/src/react-player.tsx
@@ -35,6 +35,18 @@ export interface Props extends React.HTMLAttributes<HTMLDivElement> {
   worker?: boolean;
 }
 
+const styles: Record<string, React.CSSProperties> = {
+  animation: {
+    position: 'relative',
+    width: '100%',
+    height: '100%',
+  },
+  // With controls Users must import css
+  animationWithControls: {
+    position: 'relative',
+  },
+};
+
 export const DotLottiePlayer = React.forwardRef<DotLottieCommonPlayer | null, Props>(
   (
     {
@@ -296,7 +308,7 @@ export const DotLottiePlayer = React.forwardRef<DotLottieCommonPlayer | null, Pr
             data-name={`${currentAnimationId}`}
             role="figure"
             className={`animation ${children ? 'controls' : ''}`}
-            style={{ position: 'relative' }}
+            style={children ? styles.animationWithControls : styles.animation}
             {...(testId && {
               'data-testid': `animation`,
             })}


### PR DESCRIPTION
## Description
- [x] Added style width, height 100% to .animation div. This would removed the use of css file when controls are not used. This will allows `.animation` div to respect the parent divs size without the need of importing css file.
<!--
Please include a summary of what you want to achieve in this pull request.

If this addresses an existing issue, please include the issue number in the #1234 form.
-->

## Type of change

<!--
Remember to indicate the affected component/package(s), as well as the type of change for each component/package.

Adding an x between the [ ] will render it as a checked box (i.e. [x]).
-->

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Docs: Documentation updates (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested my changes on the player-component and React player.