### PR TITLE
fix: 🐛 tsconfig jsx compile option for react 16.8 compatibility

### DIFF
--- a/.changeset/thirty-birds-invite.md
+++ b/.changeset/thirty-birds-invite.md
@@ -1,0 +1,5 @@
+---
+'@dotlottie/react-player': patch
+---
+
+fix: 🐛 tsconfig jsx compile option for react 16.8 compatibility

--- a/packages/react-player/tsconfig.json
+++ b/packages/react-player/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Description

The 'jsx' option in tsconfig.json has been changed from 'react-jsx' to 'react', enabling the package to be used across a wider range of React versions



<!--
Please include a summary of what you want to achieve in this pull request.

If this addresses an existing issue, please include the issue number in the #1234 form.
-->

## Type of change

<!--
Remember to indicate the affected component/package(s), as well as the type of change for each component/package.

Adding an x between the [ ] will render it as a checked box (i.e. [x]).
-->

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Docs: Documentation updates (if none of the other choices apply)

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested my changes on the player-component and React player.