### PR TITLE
fix: 🐛 deep clone lottie json does shallow copy for nested keys

### DIFF
--- a/.changeset/new-bats-rush.md
+++ b/.changeset/new-bats-rush.md
@@ -1,0 +1,5 @@
+---
+'@dotlottie/common': patch
+---
+
+fix: 🐛 deep clone lottie json does shallow copy for nested keys

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -81,15 +81,6 @@ export function getKeyByValue<T extends Record<string, unknown>, V>(object: T, v
  * @param obj  - Lottie JSON
  * @returns  - Deep clone of the Lottie JSON
  */
-export function deepCloneLottieJson(obj: Record<string, unknown>): Record<string, unknown> {
-  return Object.keys(obj).reduce((accumulator: Record<string, unknown>, key: string) => {
-    const value = obj[key];
-
-    return Object.assign(accumulator, {
-      [key]:
-        value instanceof Object && value.constructor === Object
-          ? deepCloneLottieJson(value as Record<string, unknown>)
-          : value,
-    });
-  }, {});
+export function deepCloneLottieJson<T>(obj: T): T {
+  return JSON.parse(JSON.stringify(obj));
 }


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request.

If this addresses an existing issue, please include the issue number in the #1234 form.
-->

## Type of change

<!--
Remember to indicate the affected component/package(s), as well as the type of change for each component/package.

Adding an x between the [ ] will render it as a checked box (i.e. [x]).
-->

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Docs: Documentation updates (if none of the other choices apply)

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested my changes on the player-component and React player.