### PR TITLE
fix: 🐛 playback ends on lastFrame

### DIFF
--- a/.changeset/wet-eagles-pump.md
+++ b/.changeset/wet-eagles-pump.md
@@ -1,0 +1,7 @@
+---
+'@dotlottie/player-component': patch
+'@dotlottie/react-player': patch
+'@dotlottie/common': patch
+---
+
+fix: 🐛 playback ends on lastFrame

--- a/packages/common/src/dotlottie-player.ts
+++ b/packages/common/src/dotlottie-player.ts
@@ -1564,7 +1564,7 @@ export class DotLottieCommonPlayer {
     // If loop = number, and animation has reached the end, call stop to go to frame 0
     if (typeof this._loop === 'number') this.stop();
 
-    const lastFrame = this.direction === -1 ? 0 : this.totalFrames;
+    const lastFrame = this.direction === -1 ? 0 : this.totalFrames - 1;
 
     this.goToAndStop(lastFrame, true);
 

--- a/packages/player-component/cypress/component/interactivity/enable-interactivity.cy.ts
+++ b/packages/player-component/cypress/component/interactivity/enable-interactivity.cy.ts
@@ -53,7 +53,7 @@ describe('Interactivity: enter/exit interactivity', () => {
     cy.get('[name="currentState"]').should('have.value', PlayerState.Playing);
     cy.get('[name="loop"]').should('have.value', 'false');
     cy.get('[name="autoplay"]').should('have.value', 'false');
-    cy.get('[name="frame"]').should('have.value', 30);
+    cy.get('[name="frame"]').should('have.value', 29);
     cy.get('[name="speed"]').should('have.value', 1);
 
     // State: playReverse

--- a/packages/player-component/cypress/component/interactivity/state-toggle.cy.ts
+++ b/packages/player-component/cypress/component/interactivity/state-toggle.cy.ts
@@ -40,7 +40,7 @@ describe('Interactivity: state_toggle (onClick)', () => {
     cy.get('[name="currentState"]').should('have.value', PlayerState.Playing);
     cy.get('[name="loop"]').should('have.value', "false");
     cy.get('[name="autoplay"]').should('have.value', "false");
-    cy.get('[name="frame"]').should('have.value', 30);
+    cy.get('[name="frame"]').should('have.value', 29);
 
     // State: playReverse
     cy.get('[data-testid="testPlayer"]').shadow().find('.animation').click({force:true});

--- a/packages/react-player/cypress/component/interactivity/enable-interactivity.cy.tsx
+++ b/packages/react-player/cypress/component/interactivity/enable-interactivity.cy.tsx
@@ -78,7 +78,7 @@ describe('Interactivity: enter/exit interactivity', () => {
     cy.get('[name="currentState"]').should('have.value', PlayerState.Playing);
     cy.get('[name="loop"]').should('have.value', 'false');
     cy.get('[name="autoplay"]').should('have.value', 'false');
-    cy.get('[name="frame"]').should('have.value', 30);
+    cy.get('[name="frame"]').should('have.value', 29);
     cy.get('[name="speed"]').should('have.value', 1);
 
     // State: playReverse

--- a/packages/react-player/cypress/component/interactivity/state-toggle.cy.tsx
+++ b/packages/react-player/cypress/component/interactivity/state-toggle.cy.tsx
@@ -58,7 +58,7 @@ describe('Interactivity: state_toggle (onClick)', () => {
     cy.get('[name="currentState"]').should('have.value', PlayerState.Playing);
     cy.get('[name="loop"]').should('have.value', 'false');
     cy.get('[name="autoplay"]').should('have.value', 'false');
-    cy.get('[name="frame"]').should('have.value', 30);
+    cy.get('[name="frame"]').should('have.value', 29);
 
     // State: playReverse
     cy.get('.animation').click({ force: true });


### PR DESCRIPTION
This fix ends playback on lastFrame - 1.

## Description

<!--
Please include a summary of what you want to achieve in this pull request.

If this addresses an existing issue, please include the issue number in the #1234 form.
-->

## Type of change

<!--
Remember to indicate the affected component/package(s), as well as the type of change for each component/package.

Adding an x between the [ ] will render it as a checked box (i.e. [x]).
-->

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Docs: Documentation updates (if none of the other choices apply)

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested my changes on the player-component and React player.